### PR TITLE
Add API controllers, routes, and a txt file with documentation

### DIFF
--- a/API_doc.txt
+++ b/API_doc.txt
@@ -1,0 +1,102 @@
+######## To create a user: ########
+
+POST request to http://localhost:3000//users
+headers: {
+  'Content-Type': 'application/json',
+},
+body: {
+  "username":"username1",
+  "role":1
+}
+
+######## To login: ########
+
+POST request to http://localhost:3000//login
+headers: {
+  'Content-Type': 'application/json',
+},
+body: 
+{
+  "username":"actual_username"
+}
+The response:
+{
+    "user": {
+        "id": 1,
+        "username": "username1",
+        "created_at": "2023-10-26T19:03:28.016Z",
+        "updated_at": "2023-10-26T19:03:28.016Z",
+        "role": 1
+    },
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxfQ.oT7kSePnYs7eVIsRIzIi0UEC7XBclsrO3qrnXwic8Zg" ### THIS IS THE TOKEN
+}
+
+######## To make any other call to the API, you must add a header: ########
+headers: {
+  'Authorization': `bearer ${token}`
+}
+The token is taken from the response of the login or create call.
+
+######## To create a parachute: ########
+POST request to http://localhost:3000//parachutes
+headers: {
+  'Content-Type': 'application/json',
+  'Authorization': `bearer ${token}`
+},
+Body:
+{
+  "name": "Not-Parachute",
+  "city": "Valdivia",
+  "rent": 9.9,
+  "description": "A not-parachute for people who doesn't want to stop their falling",
+  "min_duration": 1
+}
+
+######## To get all parachutes: ########
+GET request to http://localhost:3000//parachutes
+headers: {
+  'Authorization': `bearer ${token}`
+}
+
+######## To get a single parachute: ########
+GET request to http://localhost:3000//parachutes/(:id)
+headers: {
+  'Authorization': `bearer ${token}`
+}
+
+######## To remove a single parachute: ########
+DELETE request to http://localhost:3000//parachutes/(:id)
+headers: {
+  'Authorization': `bearer ${token}`
+}
+
+######## To create a reservation ########
+POST request to http://localhost:3000//parachutes
+headers: {
+  'Content-Type': 'application/json',
+  'Authorization': `bearer ${token}`
+},
+Body:
+{
+  "date_and_time": "2023-10-26T20:05:28.016Z",
+  "parachute_id": 2,
+  "duration": 1
+}
+
+######## To get all reservations: ########
+GET request to http://localhost:3000//reservations
+headers: {
+  'Authorization': `bearer ${token}`
+}
+
+######## To get a single reservation: ########
+GET request to http://localhost:3000//reservations/(:id)
+headers: {
+  'Authorization': `bearer ${token}`
+}
+
+######## To remove a single reservation: ########
+DELETE request to http://localhost:3000//reservations/(:id)
+headers: {
+  'Authorization': `bearer ${token}`
+}

--- a/Gemfile
+++ b/Gemfile
@@ -34,8 +34,8 @@ gem 'bootsnap', require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-gem 'rack-cors'
 gem 'jwt'
+gem 'rack-cors'
 
 gem 'rubocop', '>= 1.0', '< 2.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'rack-cors'
 
 gem 'rubocop', '>= 1.0', '< 2.0'
 
+gem 'sqlite3'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'bootsnap', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
+gem 'jwt'
 
 gem 'rubocop', '>= 1.0', '< 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
       rdoc
       reline (>= 0.3.8)
     json (2.6.3)
+    jwt (2.7.1)
     language_server-protocol (3.17.0.3)
     loofah (2.21.4)
       crass (~> 1.0.2)
@@ -196,6 +197,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
+  jwt
   pg (~> 1.1)
   puma (~> 5.0)
   rack-cors

--- a/app/controllers/parachutes_controller.rb
+++ b/app/controllers/parachutes_controller.rb
@@ -1,2 +1,39 @@
 class ParachutesController < ApplicationController
+  before_action :set_parachute, only: %i[ show destroy ]
+  before_action :authorized
+
+  def index
+    @parachute = Parachute.all
+
+    render json: @parachute
+  end
+
+  def show
+    render json: @parachute
+  end
+
+  def create
+    @parachute = Parachute.new(parachute_params)
+
+    if @parachute.save
+      render json: @parachute, status: :created, location: @parachute
+    else
+      render json: @parachute.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @parachute.destroy
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_parachute
+    @parachute = Parachute.find(params[:id])
+  end
+
+  def parachute_params
+    params.require(:parachute).permit(:name, :city, :rent, :description, :min_duration)
+  end
 end

--- a/app/controllers/parachutes_controller.rb
+++ b/app/controllers/parachutes_controller.rb
@@ -1,5 +1,5 @@
 class ParachutesController < ApplicationController
-  before_action :set_parachute, only: %i[ show destroy ]
+  before_action :set_parachute, only: %i[show destroy]
   before_action :authorized
 
   def index

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,5 +1,5 @@
 class ReservationsController < ApplicationController
-  before_action :set_reservation, only: %i[ show destroy ]
+  before_action :set_reservation, only: %i[show destroy]
   before_action :authorized
 
   def index

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,2 +1,40 @@
 class ReservationsController < ApplicationController
+  before_action :set_reservation, only: %i[ show destroy ]
+  before_action :authorized
+
+  def index
+    @reservation = Reservation.all
+
+    render json: @reservation
+  end
+
+  def show
+    render json: @reservation
+  end
+
+  def create
+    @reservation = Reservation.new(reservation_params)
+    @reservation.user = @user
+
+    if @reservation.save
+      render json: @reservation, status: :created, location: @reservation
+    else
+      render json: @reservation.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @reservation.destroy
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_reservation
+    @reservation = Reservation.find(params[:id])
+  end
+
+  def reservation_params
+    params.require(:reservation).permit(:date_and_time, :user_id, :parachute_id, :duration)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,8 +5,8 @@ class UsersController < ApplicationController
   def create
     @user = User.create(user_params)
     if @user.valid?
-      token = enconde_token({ user_id: @user.id })
-      render json: { user: @user, token: }
+      token = encode_token({ user_id: @user.id })
+      render json: { user: @user, token: token}
     else
       render json: { error: 'Invalid username' }
     end
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
 
     if @user
       token = encode_token({ user_id: @user.id })
-      render json: { user: @user, token: }
+      render json: { user: @user, token: token}
     else
       render json: { error: 'Invalid username' }
     end
@@ -31,6 +31,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.permit(:username)
+    params.permit(:username, :role)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
     @user = User.create(user_params)
     if @user.valid?
       token = encode_token({ user_id: @user.id })
-      render json: { user: @user, token: token}
+      render json: { user: @user, token: }
     else
       render json: { error: 'Invalid username' }
     end
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
 
     if @user
       token = encode_token({ user_id: @user.id })
-      render json: { user: @user, token: token}
+      render json: { user: @user, token: }
     else
       render json: { error: 'Invalid username' }
     end

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# exit on error
+set -o errexit
+
+bundle install
+bundle exec rake assets:precompile
+bundle exec rake assets:clean
+bundle exec rake db:migrate
+bundle exec rake db:seed

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,9 +21,9 @@ default: &default
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
-  username: emilokiju
-  password: PiCo123+
-  host: localhost
+  # username: emilokiju
+  # password: PiCo123+
+  # host: localhost
 
 development:
   <<: *default
@@ -85,4 +85,4 @@ test:
 #
 production:
   <<: *default
-  database: parachute_back_end_production
+  url: <%= ENV['DATABASE_URL'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present? || ENV['RENDER'].present?
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,14 +30,14 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 4 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,6 @@ Rails.application.routes.draw do
   resource :users, only: [:create]
   post '/login', to: 'users#login'
   get 'auto_login', to: 'users#auto_login'
+  resources :parachutes, only: [:index, :show, :create, :destroy]
+  resources :reservations, only: [:index, :show, :create, :destroy]
 end

--- a/db/migrate/20231026165654_create_reservations.rb
+++ b/db/migrate/20231026165654_create_reservations.rb
@@ -1,7 +1,7 @@
 class CreateReservations < ActiveRecord::Migration[7.0]
   def change
     create_table :reservations do |t|
-      t.string :date_and_time
+      t.datetime :date_and_time
       t.references :user, null: false, foreign_key: true
       t.references :parachute, null: false, foreign_key: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_26_011209) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_26_174811) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "parachutes", force: :cascade do |t|
+    t.string "name"
+    t.string "city"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.decimal "rent"
+    t.text "description"
+    t.integer "min_duration"
+  end
+
+  create_table "reservations", force: :cascade do |t|
+    t.datetime "date_and_time"
+    t.bigint "user_id", null: false
+    t.bigint "parachute_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "duration"
+    t.index ["parachute_id"], name: "index_reservations_on_parachute_id"
+    t.index ["user_id"], name: "index_reservations_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "username"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "role"
   end
 
+  add_foreign_key "reservations", "parachutes"
+  add_foreign_key "reservations", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,5 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+user = User.create(username: 'username1', role: 1)
+parachute1 = Parachute.create(name: 'Not-parachute', city: 'Valdivia', rent: 9.9, description: 'A parachute that does not want yo keep you in the air. Perfect for people who likes to stay grounded', min-duration: 1)
+parachute2 = Parachute.create(name: 'Parachute ak-47', city: 'Valdivia', rent: 19.9, description: 'This parachute will blow up your emotions! (and maybe your body)', min-duration: 1)
+parachute3 = Parachute.create(name: 'Pearachute', city: 'Valdivia', rent: 49.9, description: 'For fruits lovers, this is a pear-ticular parachute made of pears', min-duration: 1)
+parachute4 = Parachute.create(name: 'Super Sky-driving', city: 'Valdivia', rent: 99.9, description: 'Why would you dive the sky if you can drive it right?', min-duration: 1)

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,18 @@
+databases:
+  - name: Parachute-db
+    databaseName: Parachute-db
+    user: Parachute-db
+
+services:
+  - type: web
+    name: mysite
+    runtime: ruby
+    buildCommand: "./bin/render-build.sh"
+    startCommand: "bundle exec puma -C config/puma.rb"
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: mysite
+          property: connectionString
+      - key: RAILS_MASTER_KEY
+        sync: false


### PR DESCRIPTION
Added controlers and routes for:
users: create
parachutes: create, index, show, delete
reservations: create, index, show, delete

Implemented login using API with token system, using the jwt gem. Here's how you use Postman to autologin when doing API requests to other routes than login:

![image](https://github.com/EmiLoKiJu/parachute-back-end/assets/84760694/61a80668-3e06-4191-aaca-4bbff6af0631)

More info in the API_doc.txt.

In javascript, the call to login using axios looks like this:

```
const response = await axios.post('http://localhost:3000/login', {
  username: user
}, {
  headers: {
    'Content-Type': 'application/json',
  },
});
```

The call to any site with the Authorize header using axios looks like this:

```
export const getGreetings = createAsyncThunk('greetings/getGreetings', async (token) => {
  console.log(token);
  const response = await axios.get(
    'http://localhost:3000/greetings/random',
    { headers: {
        'Authorization': `bearer ${token}`
      }
    }
  );
  return response.data.greeting;
});
```